### PR TITLE
match current pinned versions frozen in airflow_etl

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 # NOTE: When updating botocore make sure to update awscli/boto3 versions below
 install_requires = [
     # pegged to also match items in `extras_require`
-    'botocore>=1.20.106,<1.20.107',
+    'botocore>=1.18.18',
     'aiohttp>=3.3.1',
     'wrapt>=1.10.10',
     'aioitertools>=0.5.1',
@@ -20,7 +20,7 @@ def read(f):
 
 extras_require = {
     'awscli': ['awscli>=1.19.106,<1.19.107'],
-    'boto3': ['boto3>=1.17.106,<1.17.107'],
+    'boto3': ['boto3>=1.15.18'],
 }
 
 


### PR DESCRIPTION
airflow_etl is currently pinned to botocore==1.18.18 and boto3==1.15.18. Hopefully this repo still works by lowering the versions???